### PR TITLE
Mandate API endpoints: submit consent

### DIFF
--- a/src/TrueLayer/Mandates/IMandatesApi.cs
+++ b/src/TrueLayer/Mandates/IMandatesApi.cs
@@ -129,6 +129,6 @@ namespace TrueLayer.Mandates
         /// </param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation</param>
         /// <returns>An API response that includes the payment details if successful, otherwise problem details</returns>
-        Task<ApiResponse> RevokeMandate(string id, string idempotencyKey, CancellationToken cancellationToken = default);
+        Task<ApiResponse> RevokeMandate(string id, string idempotencyKey, MandateType mandateType, CancellationToken cancellationToken = default);
     }
 }

--- a/src/TrueLayer/Mandates/IMandatesApi.cs
+++ b/src/TrueLayer/Mandates/IMandatesApi.cs
@@ -85,6 +85,19 @@ namespace TrueLayer.Mandates
             string mandateId, SubmitProviderSelectionRequest request, string idempotencyKey, MandateType mandateType, CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Submit the consent given by the user
+        /// </summary>
+        /// <param name="mandateId">The id of the mandate</param>
+        /// <param name="mandateType">The type of the mandate. Either sweeping or commercial</param>
+        /// <param name="idempotencyKey">
+        /// An idempotency key to allow safe retrying without the operation being performed multiple times.
+        /// The value should be unique for each operation, e.g. a UUID, with the same key being sent on a retry of the same request.
+        /// </param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation</param>
+        /// <returns>An API response that includes the authorization flow action details if successful, otherwise problem details</returns>
+        Task<ApiResponse<AuthorizationResponseUnion>> SubmitConsent(string mandateId, MandateType mandateType, string idempotencyKey, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Get Confirmation Of Funds
         /// </summary>
         /// <param name="mandateId">The id of the mandate to retrieve</param>

--- a/src/TrueLayer/Mandates/IMandatesApi.cs
+++ b/src/TrueLayer/Mandates/IMandatesApi.cs
@@ -95,7 +95,7 @@ namespace TrueLayer.Mandates
         /// </param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation</param>
         /// <returns>An API response that includes the authorization flow action details if successful, otherwise problem details</returns>
-        Task<ApiResponse<AuthorizationResponseUnion>> SubmitConsent(string mandateId, MandateType mandateType, string idempotencyKey, CancellationToken cancellationToken = default);
+        Task<ApiResponse<AuthorizationResponseUnion>> SubmitConsent(string mandateId, string idempotencyKey, MandateType mandateType, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get Confirmation Of Funds

--- a/src/TrueLayer/Mandates/MandatesApi.cs
+++ b/src/TrueLayer/Mandates/MandatesApi.cs
@@ -152,7 +152,7 @@ namespace TrueLayer.Mandates
             );
         }
 
-        public async Task<ApiResponse<AuthorizationResponseUnion>> SubmitConsent(string mandateId, MandateType mandateType, string idempotencyKey, CancellationToken cancellationToken = default)
+        public async Task<ApiResponse<AuthorizationResponseUnion>> SubmitConsent(string mandateId, string idempotencyKey, MandateType mandateType, CancellationToken cancellationToken = default)
         {
             mandateId.NotNullOrWhiteSpace(nameof(mandateId));
             idempotencyKey.NotNullOrWhiteSpace(nameof(idempotencyKey));

--- a/src/TrueLayer/Mandates/MandatesApi.cs
+++ b/src/TrueLayer/Mandates/MandatesApi.cs
@@ -212,11 +212,11 @@ namespace TrueLayer.Mandates
         }
 
         /// <inheritdoc />
-        public async Task<ApiResponse> RevokeMandate(string id, string idempotencyKey, CancellationToken cancellationToken = default)
+        public async Task<ApiResponse> RevokeMandate(string id, string idempotencyKey, MandateType mandateType, CancellationToken cancellationToken = default)
         {
             id.NotNullOrWhiteSpace(nameof(id));
 
-            ApiResponse<GetAuthTokenResponse> authResponse = await _auth.GetAuthToken(new GetAuthTokenRequest("recurring_payments:sweeping"), cancellationToken);
+            ApiResponse<GetAuthTokenResponse> authResponse = await _auth.GetAuthToken(new GetAuthTokenRequest($"recurring_payments:{mandateType.AsString()}"), cancellationToken);
 
             if (!authResponse.IsSuccessful)
             {

--- a/test/TrueLayer.AcceptanceTests/MandatesTests.cs
+++ b/test/TrueLayer.AcceptanceTests/MandatesTests.cs
@@ -242,7 +242,11 @@ namespace TrueLayer.AcceptanceTests
 
             // Act
             var response = await _fixture.Client.Mandates.RevokeMandate(
-                mandateId, idempotencyKey: Guid.NewGuid().ToString());
+                mandateId,
+                idempotencyKey: Guid.NewGuid().ToString(),
+                mandateRequest.Mandate.Match(
+                    commercialMandate => MandateType.Commercial,
+                    sweepingMandate => MandateType.Sweeping));
 
             // Assert
             response.StatusCode.ShouldBe(HttpStatusCode.NoContent);


### PR DESCRIPTION
Followed the Java SDK where this method sends empty request body (https://github.com/TrueLayer/truelayer-java/blob/ddd1994d4225591f167c4194c11487c144d51de9/src/main/java/com/truelayer/java/payments/IPaymentsApi.java#L76), despite presence of the optional "captured" object in the body params as seen in the API reference docs (https://docs.truelayer.com/reference/submit-consent-mandate)

Also added mandateType argument to the RevokeMandate method, not to hardcode the sweeping auth scope. 